### PR TITLE
Wattle func calls

### DIFF
--- a/src/WattleScript.Interpreter/CoreLib/ErrorHandlingModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/ErrorHandlingModule.cs
@@ -33,7 +33,7 @@ namespace WattleScript.Interpreter.CoreLib
 			{
 				try
 				{
-					DynValue ret = args[0].Callback.Invoke(executionContext, a);
+					DynValue ret = args[0].Callback.Invoke(executionContext, a, DynValue.Nil);
 					if (ret.Type == DataType.TailCallRequest)
 					{
 						if (ret.TailCallData.Continuation != null || ret.TailCallData.ErrorHandler != null)
@@ -125,7 +125,7 @@ namespace WattleScript.Interpreter.CoreLib
 				args.AsType(1, "xpcall", DataType.Function, false);
 			}
 
-			return SetErrorHandlerStrategy("xpcall", executionContext, new CallbackArguments(a, false), handler);
+			return SetErrorHandlerStrategy("xpcall", executionContext, new CallbackArguments(a, DynValue.Nil, false), handler);
 		}
 
 	}

--- a/src/WattleScript.Interpreter/DataTypes/CallbackArguments.cs
+++ b/src/WattleScript.Interpreter/DataTypes/CallbackArguments.cs
@@ -10,6 +10,7 @@ namespace WattleScript.Interpreter
 	{
 		IList<DynValue> m_Args;
 		int m_Count;
+		private DynValue m_implicitThis;
 		bool m_LastIsTuple = false;
 
 		/// <summary>
@@ -17,7 +18,7 @@ namespace WattleScript.Interpreter
 		/// </summary>
 		/// <param name="args">The arguments.</param>
 		/// <param name="isMethodCall">if set to <c>true</c> [is method call].</param>
-		public CallbackArguments(IList<DynValue> args, bool isMethodCall)
+		public CallbackArguments(IList<DynValue> args, DynValue implicitThis, bool isMethodCall)
 		{
 			m_Args = args;
 
@@ -45,6 +46,7 @@ namespace WattleScript.Interpreter
 			}
 
 			IsMethodCall = isMethodCall;
+			m_implicitThis = implicitThis;
 		}
 
 		/// <summary>
@@ -59,8 +61,12 @@ namespace WattleScript.Interpreter
 		/// Gets or sets a value indicating whether this is a method call.
 		/// </summary>
 		public bool IsMethodCall { get; private set; }
-
-
+		
+		public DynValue This
+		{
+			get => IsMethodCall ? this[0] : m_implicitThis;
+		}
+		
 		/// <summary>
 		/// Gets the <see cref="DynValue"/> at the specified index, or Void if not found 
 		/// </summary>
@@ -218,7 +224,7 @@ namespace WattleScript.Interpreter
 			if (this.IsMethodCall)
 			{
 				Slice<DynValue> slice = new Slice<DynValue>(m_Args, 1, m_Args.Count - 1, false);
-				return new CallbackArguments(slice, false);
+				return new CallbackArguments(slice, m_implicitThis, false);
 			}
 			else return this;
 		}

--- a/src/WattleScript.Interpreter/DataTypes/CallbackFunction.cs
+++ b/src/WattleScript.Interpreter/DataTypes/CallbackFunction.cs
@@ -43,7 +43,7 @@ namespace WattleScript.Interpreter
 		/// <param name="args">The arguments.</param>
 		/// <param name="isMethodCall">if set to <c>true</c> this is a method call.</param>
 		/// <returns></returns>
-		public DynValue Invoke(ScriptExecutionContext executionContext, IList<DynValue> args, bool isMethodCall = false)
+		public DynValue Invoke(ScriptExecutionContext executionContext, IList<DynValue> args, DynValue implicitThis, bool isMethodCall = false)
 		{
 			if (isMethodCall)
 			{
@@ -55,7 +55,7 @@ namespace WattleScript.Interpreter
 					isMethodCall = (args.Count > 0 && args[0].Type == DataType.UserData);
 			}
 
-			return ClrCallback(executionContext, new CallbackArguments(args, isMethodCall));
+			return ClrCallback(executionContext, new CallbackArguments(args, implicitThis, isMethodCall));
 		}
 
 		/// <summary>

--- a/src/WattleScript.Interpreter/DataTypes/Closure.cs
+++ b/src/WattleScript.Interpreter/DataTypes/Closure.cs
@@ -120,6 +120,25 @@ namespace WattleScript.Interpreter
 			return OwnerScript.CallAsync(this, args);
 		}
 
+		public DynValue ThisCall(DynValue self)
+		{
+			return OwnerScript.ThisCall(this, self);
+		}
+		
+		public DynValue ThisCall(params DynValue[] args)
+		{
+			return OwnerScript.ThisCall(this, args);
+		}
+		
+		public Task<DynValue> ThisCallAsync(DynValue self)
+		{
+			return OwnerScript.ThisCallAsync(this, self);
+		}
+		
+		public Task<DynValue> ThisCallAsync(params DynValue[] args)
+		{
+			return OwnerScript.ThisCallAsync(this, args);
+		}
 
 		/// <summary>
 		/// Gets a delegate wrapping calls to this scripted function

--- a/src/WattleScript.Interpreter/DataTypes/Coroutine.cs
+++ b/src/WattleScript.Interpreter/DataTypes/Coroutine.cs
@@ -160,7 +160,7 @@ namespace WattleScript.Interpreter
 				return m_Processor.Coroutine_Resume(args);
 			else if (Type == CoroutineType.ClrCallback)
 			{
-				DynValue ret = m_ClrCallback.Invoke(context, args);
+				DynValue ret = m_ClrCallback.Invoke(context, args, DynValue.Nil);
 				MarkClrCallbackAsDead();
 				return ret;
 			}

--- a/src/WattleScript.Interpreter/Execution/ScriptExecutionContext.cs
+++ b/src/WattleScript.Interpreter/Execution/ScriptExecutionContext.cs
@@ -149,7 +149,7 @@ namespace WattleScript.Interpreter
 			{
 				while (true)
 				{
-					DynValue ret = func.Callback.Invoke(this, args, false);
+					DynValue ret = func.Callback.Invoke(this, args, DynValue.Nil, false);
 
 					if (ret.Type == DataType.YieldRequest)
 					{

--- a/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
@@ -1,17 +1,25 @@
+using System;
 using WattleScript.Interpreter.Debugging;
 
 namespace WattleScript.Interpreter.Execution.VM
 {
+    [Flags]
+    enum FunctionFlags
+    {
+        None = 0x0,
+        IsChunk = 0x1,
+        TakesSelf = 0x2,
+        ImplicitThis = 0x4
+    }
     class FunctionProto
     {
         //Function Data
         public string Name;
-        public bool IsChunk;
+        public FunctionFlags Flags;
         public SymbolRef[] Locals;
         public SymbolRef[] Upvalues;
         public Annotation[] Annotations;
         public int LocalCount;
-        public bool TakesSelf;
         //Constants
         public FunctionProto[] Functions;
         public string[] Strings;

--- a/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
@@ -11,6 +11,7 @@ namespace WattleScript.Interpreter.Execution.VM
         public SymbolRef[] Upvalues;
         public Annotation[] Annotations;
         public int LocalCount;
+        public bool TakesSelf;
         //Constants
         public FunctionProto[] Functions;
         public string[] Strings;

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
@@ -146,6 +146,7 @@ namespace WattleScript.Interpreter.Execution.VM
 				WriteDynValue(bw, ant.Value, true);
 			}
 			bw.WriteVarUInt32((uint)function.LocalCount);
+			bw.WriteBoolean(function.TakesSelf);
 			//Symbols
 			Dictionary<SymbolRef, int> symbolMap = new Dictionary<SymbolRef, int>();
 			bw.WriteVarUInt32((uint)function.Locals.Length);
@@ -204,6 +205,7 @@ namespace WattleScript.Interpreter.Execution.VM
 				proto.Annotations[i] = new Annotation(br.ReadString(), ReadDynValue(br, true));
 			}
 			proto.LocalCount = (int) br.ReadVarUInt32();
+			proto.TakesSelf = br.ReadBoolean();
 			//Symbols
 			proto.Locals = new SymbolRef[br.ReadVarUInt32()];
 			proto.Upvalues = new SymbolRef[br.ReadVarUInt32()];

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -376,7 +376,7 @@ namespace WattleScript.Interpreter.Execution.VM
 
 						var cbargs = new[] { DynValue.NewString(e.DecoratedMessage) };
 
-						DynValue handled = csi.ErrorHandler.Invoke(new ScriptExecutionContext(this, csi.ErrorHandler, GetCurrentSourceRef(instructionPtr)), cbargs);
+						DynValue handled = csi.ErrorHandler.Invoke(new ScriptExecutionContext(this, csi.ErrorHandler, GetCurrentSourceRef(instructionPtr)), cbargs, DynValue.Nil);
 
 						m_ValueStack.Push(handled);
 
@@ -412,7 +412,7 @@ namespace WattleScript.Interpreter.Execution.VM
 				else if (messageHandler.Type == DataType.ClrFunction)
 				{
 					ScriptExecutionContext ctx = new ScriptExecutionContext(this, messageHandler.Callback, sourceRef);
-					ret = messageHandler.Callback.Invoke(ctx, args);
+					ret = messageHandler.Callback.Invoke(ctx, args, DynValue.Nil);
 				}
 				else
 				{
@@ -624,7 +624,7 @@ namespace WattleScript.Interpreter.Execution.VM
 
 		private IList<DynValue> CreateArgsListForFunctionCall(int numargs, int offsFromTop)
 		{
-			if (numargs == 0) return Array.Empty<DynValue>();
+			if (numargs <= 0) return Array.Empty<DynValue>();
 
 			DynValue lastParam = m_ValueStack.Peek(offsFromTop);
 
@@ -646,15 +646,30 @@ namespace WattleScript.Interpreter.Execution.VM
 		
 		private void ExecArgs(Instruction I)
 		{
-			int localCount = m_ExecutionStack.Peek().Function.LocalCount;
+			var stackframe = m_ExecutionStack.Peek();
+
+			int localCount = stackframe.Function.LocalCount;
 			int numargs = (int)m_ValueStack.Peek(localCount).Number;
+			bool implicitThis = false;
+			if (numargs < 0)
+			{
+				numargs = -numargs;
+				implicitThis = true;
+			}
+
 			// unpacks last tuple arguments to simplify a lot of code down under
 			var argsList = CreateArgsListForFunctionCall(numargs, 1 + localCount);
-			var stackframe = m_ExecutionStack.Peek();
-			
+
+			int offset = 0;
+			//Skip implicit this passed on stack
+			if (implicitThis && !stackframe.Function.TakesSelf) {
+				offset = 1;
+			}
+			//
 			for (int i = 0; i < I.NumVal; i++)
 			{
-				if (i >= argsList.Count) {
+				int argIdx = i + offset;
+				if (argIdx >= argsList.Count) {
 					//Argument locals are stored in reverse order
 					//This is to do with some edge cases in argument naming
 					m_ValueStack[stackframe.BasePointer + (I.NumVal - i - 1)] = DynValue.Nil;
@@ -662,18 +677,18 @@ namespace WattleScript.Interpreter.Execution.VM
 				//Make a tuple if the last argument is varargs
 				else if (i == I.NumVal - 1 && I.NumVal2 != 0)
 				{
-					int len = argsList.Count - i;
+					int len = argsList.Count - argIdx;
 					DynValue[] varargs = new DynValue[len];
 
-					for (int ii = 0; ii < len; ii++, i++)
+					for (int ii = 0; ii < len; ii++, argIdx++)
 					{
-						varargs[ii] = argsList[i].ToScalar();
+						varargs[ii] = argsList[argIdx].ToScalar();
 					}
 					m_ValueStack[stackframe.BasePointer] = DynValue.NewTuple(Internal_AdjustTuple(varargs));
 				}
 				else
 				{
-					m_ValueStack[stackframe.BasePointer + (I.NumVal - i - 1)] = argsList[i].ToScalar();
+					m_ValueStack[stackframe.BasePointer + (I.NumVal - i - 1)] = argsList[argIdx].ToScalar();
 				}
 			}
 		}
@@ -681,6 +696,8 @@ namespace WattleScript.Interpreter.Execution.VM
 		private int Internal_ExecCall(bool canAwait, int argsCount, int instructionPtr, CallbackFunction handler = null,
 			CallbackFunction continuation = null, bool thisCall = false, string debugText = null, DynValue unwindHandler = default)
 		{
+			bool implicitThis = argsCount < 0;
+			if (implicitThis) argsCount = -argsCount;
 			DynValue fn = m_ValueStack.Peek(argsCount);
 			CallStackItemFlags flags = (thisCall ? CallStackItemFlags.MethodCall : CallStackItemFlags.None);
 
@@ -714,8 +731,9 @@ namespace WattleScript.Interpreter.Execution.VM
 			{
 				case DataType.ClrFunction:
 				{
-					//IList<DynValue> args = new Slice<DynValue>(m_ValueStack, m_ValueStack.Count - argsCount, argsCount, false);
-					IList<DynValue> args = CreateArgsListForFunctionCall(argsCount, 0);
+					IList<DynValue> args = CreateArgsListForFunctionCall(implicitThis ? (argsCount - 1) : argsCount, 0);
+					DynValue thisObj = DynValue.Nil;
+					if (implicitThis) thisObj = m_ValueStack[m_ValueStack.Count - argsCount];
 					// we expand tuples before callbacks
 					// args = DynValue.ExpandArgumentsToList(args);
 
@@ -734,8 +752,8 @@ namespace WattleScript.Interpreter.Execution.VM
 						ErrorHandlerBeforeUnwind = unwindHandler,
 						Flags = flags,
 					});
-
-					var ret = fn.Callback.Invoke(new ScriptExecutionContext(this, fn.Callback, sref) { CanAwait = canAwait }, args, isMethodCall: thisCall);
+					
+					var ret = fn.Callback.Invoke(new ScriptExecutionContext(this, fn.Callback, sref) { CanAwait = canAwait }, args, thisObj, isMethodCall: thisCall && !implicitThis);
 					m_ValueStack.RemoveLast(argsCount + 1);
 					if (m_Script.Options.AutoAwait && 
 					    ret.Type == DataType.UserData &&
@@ -751,7 +769,7 @@ namespace WattleScript.Interpreter.Execution.VM
 					return Internal_CheckForTailRequests(canAwait, instructionPtr);
 				}
 				case DataType.Function:
-					m_ValueStack.Push(DynValue.NewNumber(argsCount));
+					m_ValueStack.Push(DynValue.NewNumber(implicitThis ? -argsCount : argsCount));
 					m_ExecutionStack.Push(new CallStackItem()
 					{
 						ReturnAddress = instructionPtr,
@@ -800,6 +818,7 @@ namespace WattleScript.Interpreter.Execution.VM
 			CallStackItem csi = PopToBasePointer();
 			int retpoint = csi.ReturnAddress;
 			var argscnt = (int)(m_ValueStack.Pop().Number);
+			if (argscnt < 0) argscnt = -argscnt;
 			m_ValueStack.RemoveLast(argscnt + 1);
 
 			// Re-push all cur args and func ptr
@@ -845,6 +864,7 @@ namespace WattleScript.Interpreter.Execution.VM
 					csi = PopToBasePointer();
 					retpoint = csi.ReturnAddress;
 					var argscnt = (int)(m_ValueStack.Pop().Number);
+					if (argscnt < 0) argscnt = -argscnt;
 					m_ValueStack.RemoveLast(argscnt + 1);
 					m_ValueStack.Push(DynValue.Void);
 					break;
@@ -855,6 +875,7 @@ namespace WattleScript.Interpreter.Execution.VM
 					csi = PopToBasePointer();
 					retpoint = csi.ReturnAddress;
 					var argscnt = (int)(m_ValueStack.Pop().Number);
+					if (argscnt < 0) argscnt = -argscnt;
 					m_ValueStack.RemoveLast(argscnt + 1);
 					m_ValueStack.Push(retval);
 					retpoint = Internal_CheckForTailRequests(false, retpoint);
@@ -866,7 +887,7 @@ namespace WattleScript.Interpreter.Execution.VM
 
 			if (csi.Continuation != null)
 				m_ValueStack.Push(csi.Continuation.Invoke(new ScriptExecutionContext(this, csi.Continuation, csi.Function.SourceRefs[currentPtr]),
-					new[] { m_ValueStack.Pop() }));
+					new[] { m_ValueStack.Pop() }, DynValue.Nil));
 
 			return retpoint;
 		}

--- a/src/WattleScript.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
+++ b/src/WattleScript.Interpreter/Interop/BasicDescriptors/DispatchingUserDataDescriptor.cs
@@ -454,7 +454,7 @@ namespace WattleScript.Interpreter.Interop.BasicDescriptors
 				}
 			}
 
-			CallbackArguments args = new CallbackArguments(values, false);
+			CallbackArguments args = new CallbackArguments(values, DynValue.Nil, false);
 			ScriptExecutionContext execCtx = script.CreateDynamicExecutionContext();
 
 			DynValue v = mdesc.GetValue(script, obj);

--- a/src/WattleScript.Interpreter/Script.cs
+++ b/src/WattleScript.Interpreter/Script.cs
@@ -517,7 +517,7 @@ namespace WattleScript.Interpreter
 			}
 			else if (function.Type == DataType.ClrFunction)
 			{
-				return function.Callback.ClrCallback(this.CreateDynamicExecutionContext(function.Callback), new CallbackArguments(args, false));
+				return function.Callback.ClrCallback(this.CreateDynamicExecutionContext(function.Callback), new CallbackArguments(args, DynValue.Nil, false));
 			}
 
 			return m_MainProcessor.Call(function, args);
@@ -550,7 +550,7 @@ namespace WattleScript.Interpreter
 			else if (function.Type == DataType.ClrFunction)
 			{
 				return Task.FromResult(function.Callback.ClrCallback(
-					this.CreateDynamicExecutionContext(function.Callback), new CallbackArguments(args, false)));
+					this.CreateDynamicExecutionContext(function.Callback), new CallbackArguments(args, DynValue.Nil, false)));
 			}
 
 			return m_MainProcessor.CallAsync(function, args);

--- a/src/WattleScript.Interpreter/Tree/Expression_.cs
+++ b/src/WattleScript.Interpreter/Tree/Expression_.cs
@@ -271,10 +271,20 @@ namespace WattleScript.Interpreter.Tree
 								index = new ExprListExpression(explist, lcontext);
 							}
 							CheckMatch(lcontext, openBrk, TokenType.Brk_Close_Square, "]");
+							//Regular indexing
 							var ne = new IndexExpression(e, index, T.Type == TokenType.BrkOpenSquareNil, lcontext);
 							//Break nil checking chain on next nil check
-							if (e is IndexExpression ie && T.Type != TokenType.BrkOpenSquareNil) ie.NilChainNext = ne;
+							if (e is IndexExpression ie && T.Type != TokenType.BrkOpenSquareNil)
+								ie.NilChainNext = ne;
 							e = ne;
+							if (lcontext.Lexer.Current.Type == TokenType.Brk_Open_Round &&
+							    lcontext.Syntax == ScriptSyntax.WattleScript)
+							{
+								//Function call
+								var call = new FunctionCallExpression(lcontext, ne, null, CallKind.ImplicitThisCall);
+								ne.NilChainNext = call;
+								e = call;
+							}
 							break;
 						}
 					case TokenType.Colon when lcontext.Syntax != ScriptSyntax.WattleScript:

--- a/src/WattleScript.Interpreter/Tree/Expression_.cs
+++ b/src/WattleScript.Interpreter/Tree/Expression_.cs
@@ -182,9 +182,9 @@ namespace WattleScript.Interpreter.Tree
 					return new SymbolRefExpression(t, lcontext);
 				case TokenType.Function:
 					lcontext.Lexer.Next();
-					return new FunctionDefinitionExpression(lcontext, false, false);
+					return new FunctionDefinitionExpression(lcontext, SelfType.None, false);
 				case TokenType.Lambda:
-					return new FunctionDefinitionExpression(lcontext, false, true);
+					return new FunctionDefinitionExpression(lcontext, SelfType.None, true);
 				case TokenType.Brk_Open_Round:
 				{
 					if (lcontext.Syntax == ScriptSyntax.Lua) return PrimaryExp(lcontext);
@@ -200,7 +200,7 @@ namespace WattleScript.Interpreter.Tree
 					bool arrowLambda = lcontext.Lexer.Current.Type == TokenType.Arrow || lcontext.Lexer.PeekNext().Type == TokenType.Arrow;
 					lcontext.Lexer.RestorePos();
 					if (arrowLambda) 					
-						return new FunctionDefinitionExpression(lcontext, false, true);
+						return new FunctionDefinitionExpression(lcontext, SelfType.None, true);
 					else
 						return PrimaryExp(lcontext);
 				}
@@ -219,7 +219,7 @@ namespace WattleScript.Interpreter.Tree
 		{
 			if (lcontext.Lexer.PeekNext().Type == TokenType.Arrow && lcontext.Lexer.Current.Type == TokenType.Name)
 			{
-				return new FunctionDefinitionExpression(lcontext, false, true);
+				return new FunctionDefinitionExpression(lcontext, SelfType.None, true);
 			}
 
 			Expression e = PrefixExp(lcontext);

--- a/src/WattleScript.Interpreter/Tree/Expressions/FunctionCallExpression.cs
+++ b/src/WattleScript.Interpreter/Tree/Expressions/FunctionCallExpression.cs
@@ -85,15 +85,24 @@ namespace WattleScript.Interpreter.Tree.Expressions
 
 		public override void Compile(Execution.VM.FunctionBuilder bc)
 		{
-			m_Function.Compile(bc);
+			int argslen = m_Arguments.Count;
+
+			if (m_Kind == CallKind.ImplicitThisCall && m_Name == null)
+			{
+				((IndexExpression)m_Function).Compile(bc, true);
+				bc.Emit_Swap(0, 1);
+				++argslen;
+			}
+			else
+			{
+				m_Function.Compile(bc);
+			}
 
 			int nilCoalesce = -1;
 			if (m_Kind == CallKind.ImplicitThisSkipNil)
 			{
 				nilCoalesce = bc.Emit_Jump(OpCode.JNilChk, -1);
 			}
-			
-			int argslen = m_Arguments.Count;
 
 			if (!string.IsNullOrEmpty(m_Name))
 			{

--- a/src/WattleScript.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
+++ b/src/WattleScript.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
@@ -335,7 +335,12 @@ namespace WattleScript.Interpreter.Tree.Expressions
 			var proto = bc.GetProto(funcName, m_StackFrame);
 			proto.Annotations = m_Annotations;
 			proto.Upvalues = m_Closure.ToArray();
-			
+			if (m_ParamNames.Length > 0)
+			{
+				proto.TakesSelf = lcontext.Syntax == ScriptSyntax.Lua
+					? m_ParamNames[0].i_Name == "self"
+					: m_ParamNames[0].i_Name == "this";
+			}
 			if(parent != null) parent.Protos.Add(proto);
 			
 			return proto;

--- a/src/WattleScript.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
+++ b/src/WattleScript.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
@@ -9,6 +9,12 @@ using WattleScript.Interpreter.Tree.Statements;
 
 namespace WattleScript.Interpreter.Tree.Expressions
 {
+	enum SelfType
+	{
+		None,
+		Explicit,
+		Implicit
+	}
 	class FunctionDefinitionExpression : Expression, IClosureBuilder
 	{
 		SymbolRef[] m_ParamNames = null;
@@ -17,6 +23,7 @@ namespace WattleScript.Interpreter.Tree.Expressions
 		List<SymbolRef> m_Closure = new List<SymbolRef>();
 		private Annotation[] m_Annotations;
 		bool m_HasVarArgs = false;
+		bool m_ImplicitThis = false;
 		
 		private FunctionBuilder m_bc = null;
 		
@@ -28,14 +35,14 @@ namespace WattleScript.Interpreter.Tree.Expressions
 		List<FunctionDefinitionStatement.FunctionParamRef> paramnames;
 
 		public FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool usesGlobalEnv)
-			: this(lcontext, false, usesGlobalEnv, false)
+			: this(lcontext, SelfType.None, usesGlobalEnv, false)
 		{ }
 
-		public FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool pushSelfParam, bool isLambda)
-			: this(lcontext, pushSelfParam, false, isLambda)
+		public FunctionDefinitionExpression(ScriptLoadingContext lcontext, SelfType self, bool isLambda)
+			: this(lcontext, self, false, isLambda)
 		{ }
 		
-		private FunctionDefinitionExpression(ScriptLoadingContext lcontext, bool pushSelfParam, bool usesGlobalEnv, bool isLambda)
+		private FunctionDefinitionExpression(ScriptLoadingContext lcontext, SelfType self, bool usesGlobalEnv, bool isLambda)
 			: base(lcontext)
 		{
 			this.lcontext = lcontext;
@@ -59,12 +66,12 @@ namespace WattleScript.Interpreter.Tree.Expressions
 				if (openRound.Type == TokenType.Name)
 					paramnames = new List<FunctionDefinitionStatement.FunctionParamRef>(new FunctionDefinitionStatement.FunctionParamRef[] {new FunctionDefinitionStatement.FunctionParamRef(openRound.Text)});
 				else
-					paramnames = BuildParamList(lcontext, pushSelfParam, openRound);
+					paramnames = BuildParamList(lcontext, self, openRound);
 			}
 			else
 			{
 				openRound = CheckTokenType(lcontext, TokenType.Brk_Open_Round);
-				paramnames = BuildParamList(lcontext, pushSelfParam, openRound);
+				paramnames = BuildParamList(lcontext, self, openRound);
 				if (lcontext.Syntax != ScriptSyntax.Lua && lcontext.Lexer.Current.Type == TokenType.Brk_Open_Curly) {
 					openCurly = true;
 					lcontext.Lexer.Next();
@@ -163,16 +170,17 @@ namespace WattleScript.Interpreter.Tree.Expressions
 			return s;
 		}
 
-		private List<FunctionDefinitionStatement.FunctionParamRef> BuildParamList(ScriptLoadingContext lcontext, bool pushSelfParam, Token openBracketToken)
+		private List<FunctionDefinitionStatement.FunctionParamRef> BuildParamList(ScriptLoadingContext lcontext, SelfType self, Token openBracketToken)
 		{
 			TokenType closeToken = openBracketToken.Type == TokenType.Lambda ? TokenType.Lambda : TokenType.Brk_Close_Round;
 
 			List<FunctionDefinitionStatement.FunctionParamRef> paramnames = new List<FunctionDefinitionStatement.FunctionParamRef>();
 
 			// method decls with ':' must push an implicit 'self' param
-			if (pushSelfParam)
+			if (self != SelfType.None)
 				paramnames.Add(lcontext.Syntax == ScriptSyntax.WattleScript ? new FunctionDefinitionStatement.FunctionParamRef("this") : new FunctionDefinitionStatement.FunctionParamRef("self"));
-
+			m_ImplicitThis = self == SelfType.Implicit;
+			
 			bool parsingDefaultParams = false;
 			while (lcontext.Lexer.Current.Type != closeToken)
 			{
@@ -335,12 +343,12 @@ namespace WattleScript.Interpreter.Tree.Expressions
 			var proto = bc.GetProto(funcName, m_StackFrame);
 			proto.Annotations = m_Annotations;
 			proto.Upvalues = m_Closure.ToArray();
-			if (m_ParamNames.Length > 0)
+			if (m_ParamNames.Length > 0 && (m_ParamNames[0].i_Name == "self" || m_ParamNames[0].i_Name == "this"))
 			{
-				proto.TakesSelf = lcontext.Syntax == ScriptSyntax.Lua
-					? m_ParamNames[0].i_Name == "self"
-					: m_ParamNames[0].i_Name == "this";
+				proto.Flags |= FunctionFlags.TakesSelf;
 			}
+			if (m_ImplicitThis) proto.Flags |= FunctionFlags.ImplicitThis;
+			
 			if(parent != null) parent.Protos.Add(proto);
 			
 			return proto;

--- a/src/WattleScript.Interpreter/Tree/Expressions/IndexExpression.cs
+++ b/src/WattleScript.Interpreter/Tree/Expressions/IndexExpression.cs
@@ -73,9 +73,15 @@ namespace WattleScript.Interpreter.Tree.Expressions
 			m_IndexExp?.ResolveScope(lcontext);
 		}
 
+
 		public override void Compile(FunctionBuilder bc)
 		{
+			Compile(bc, false);
+		}
+		public void Compile(FunctionBuilder bc, bool duplicate)
+		{
 			m_BaseExp.Compile(bc);
+			if (duplicate) bc.Emit_Copy(0);
 			if (isLength) {
 				if (nilCheck) {
 					bc.NilChainTargets.Push(bc.Emit_Jump(OpCode.JNilChk, -1));

--- a/src/WattleScript.Interpreter/Tree/Statements/ChunkStatement.cs
+++ b/src/WattleScript.Interpreter/Tree/Statements/ChunkStatement.cs
@@ -48,7 +48,7 @@ namespace WattleScript.Interpreter.Tree.Statements
 			var proto = bc.GetProto("<chunk-root>", m_StackFrame);
 			proto.Annotations = annotations;
 			proto.Upvalues = new SymbolRef[] {SymbolRef.Upvalue(WellKnownSymbols.ENV, 0)};
-			proto.IsChunk = true;
+			proto.Flags = FunctionFlags.IsChunk;
 			return proto;
 		}
 

--- a/src/WattleScript.Interpreter/Tree/Statements/FunctionDefinitionStatement.cs
+++ b/src/WattleScript.Interpreter/Tree/Statements/FunctionDefinitionStatement.cs
@@ -56,6 +56,7 @@ namespace WattleScript.Interpreter.Tree.Statements
 			
 			m_Local = local;
 			Token name = CheckTokenType(lcontext, TokenType.Name);
+			SelfType selfType = SelfType.None;
 			
 			if (m_Local)
 			{
@@ -110,7 +111,13 @@ namespace WattleScript.Interpreter.Tree.Statements
 				}
 			}
 
-			m_FuncDef = new FunctionDefinitionExpression(lcontext, m_IsMethodCallingConvention, false);
+			if (m_IsMethodCallingConvention) selfType = SelfType.Explicit;
+			else if (m_MethodName != null && lcontext.Syntax == ScriptSyntax.WattleScript)
+			{
+				selfType = SelfType.Implicit;
+			}
+
+			m_FuncDef = new FunctionDefinitionExpression(lcontext, selfType, false);
 			lcontext.Source.Refs.Add(m_SourceRef);
 		}
 

--- a/src/WattleScript.Tests/EndToEnd/CSyntaxTests.cs
+++ b/src/WattleScript.Tests/EndToEnd/CSyntaxTests.cs
@@ -227,20 +227,22 @@ namespace WattleScript.Interpreter.Tests.EndToEnd
         public void ImplicitThis()
         {
             TestScript.Run(@"
-            this = 'hello'; //checking global state doesn't interfere
+            this = 'hello'; //making sure 'this' local is defined
             var tbl = {}
-            function tbl.implicitnil(arg)
-            {
-                assert.areequal(nil, this);
-                assert.areequal(7, arg);
-            }
             function tbl.implicitthis(arg)
             {
                 assert.areequal(tbl, this);
                 assert.areequal(7, arg);
             }
-            tbl['implicitnil'](7); //regular indexing = don't pass 'this'
+            function tbl.shouldnil(arg)
+            {
+                assert.areequal(nil, this);
+                assert.areequal(7, arg);
+            }
             tbl.implicitthis(7); //dot call will pass implicit 'this' parameter
+            tbl['implicitthis'](7); //regular indexing = also pass implicit 'this'
+            local fun = tbl.shouldnil;
+            fun(7); //no left hand side = no this to pass
             ", s => s.Options.Syntax = ScriptSyntax.WattleScript);
         }
 

--- a/src/WattleScript.Tests/EndToEnd/CSyntaxTests.cs
+++ b/src/WattleScript.Tests/EndToEnd/CSyntaxTests.cs
@@ -197,6 +197,31 @@ namespace WattleScript.Interpreter.Tests.EndToEnd
             Assert.AreEqual("hello", myfunc.Annotations[0].Value.Table["name"]);
             Assert.AreEqual(10, myfunc.Annotations[0].Value.Table["value"]);
         }
+
+        [Test]
+        public void DotThisCall()
+        {
+            TestScript.Run(@"
+            var tbl = { 
+                str = 'hello',
+                func2 = (x) => {   
+                    assert.areequal(nil, this);
+                    assert.areequal(7, x);
+                }
+            }
+            function tbl:hello(num) {
+                assert.areequal('hello', this?.str)
+                assert.areequal(7, num);
+            }
+            tbl.hello(7);
+            tbl::hello(7);
+            tbl.func2(7);
+
+
+            table.insert(tbl, 1, 'goodbye');
+            assert.areequal('goodbye', tbl[1]);
+            ", s => s.Options.Syntax = ScriptSyntax.WattleScript);
+        }
         
 
         [Test]


### PR DESCRIPTION
Allow wattle to pass an implicit `this` parameter when using `.` for function calls. This parameter will **not** be consumed if the first parameter of the function is not `this` for wattle or `self` for lua. 

Wattle functions defined with table syntax will now contain a `this` parameter that only can be filled by wattle's implicit this passed with `.`, or an explicit thiscall with lua's colon or wattle's double-colon syntax. Facility to call these functions from C# is added by using the new `ThisCall` and `ThisCallAsync` methods.