### PR TITLE
Implement max instruction limit

### DIFF
--- a/src/WattleScript.Interpreter/DataTypes/Coroutine.cs
+++ b/src/WattleScript.Interpreter/DataTypes/Coroutine.cs
@@ -282,7 +282,7 @@ namespace WattleScript.Interpreter
 		/// <value>
 		/// The automatic yield counter.
 		/// </value>
-		public long AutoYieldCounter
+		public ulong AutoYieldCounter
 		{
 			get { return m_Processor.AutoYieldCounter; }
 			set { m_Processor.AutoYieldCounter = value; }

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -51,7 +51,7 @@ namespace WattleScript.Interpreter.Execution.VM
 
 					if (m_Script.Options.InstructionLimit > 0 && executedInstructions > m_Script.Options.InstructionLimit)
 					{
-						throw new ScriptRuntimeException($"Maximum limit of {m_Script.Options.InstructionLimit} exceed. Script terminated.");
+						throw new ScriptRuntimeException($"Maximum limit of {m_Script.Options.InstructionLimit} exceeded. Script terminated.");
 					}
 
 					if (canAutoYield && executedInstructions > AutoYieldCounter)

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -15,7 +15,7 @@ namespace WattleScript.Interpreter.Execution.VM
 		const int YIELD_SPECIAL_TRAP = -99;
 		const int YIELD_SPECIAL_AWAIT = -100;
 
-		internal long AutoYieldCounter = 0;
+		internal ulong AutoYieldCounter = 0;
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		string GetString(int i)
@@ -27,7 +27,7 @@ namespace WattleScript.Interpreter.Execution.VM
 		{
 			// This is the main loop of the processor, has a weird control flow and needs to be as fast as possible.
 			// This sentence is just a convoluted way to say "don't complain about gotos".
-			long executedInstructions = 0;
+			ulong executedInstructions = 0;
 			bool canAutoYield = (AutoYieldCounter > 0) && m_CanYield && (State != CoroutineState.Main);
 
 			repeat_execution:
@@ -48,6 +48,11 @@ namespace WattleScript.Interpreter.Execution.VM
 					}
 
 					++executedInstructions;
+
+					if (m_Script.Options.InstructionLimit > 0 && executedInstructions > m_Script.Options.InstructionLimit)
+					{
+						throw new ScriptRuntimeException($"Maximum limit of {m_Script.Options.InstructionLimit} exceed. Script terminated.");
+					}
 
 					if (canAutoYield && executedInstructions > AutoYieldCounter)
 					{

--- a/src/WattleScript.Interpreter/ScriptOptions.cs
+++ b/src/WattleScript.Interpreter/ScriptOptions.cs
@@ -146,5 +146,11 @@ namespace WattleScript.Interpreter
 		/// Only used when <see cref="Syntax"/> is set to WattleScript
 		/// </summary>
 		public List<PreprocessorDefine> Defines { get; set; } = new List<PreprocessorDefine>();
+
+		/// <summary>
+		/// Set maximum number of instructions to be executed before forceful termination of the script.
+		/// If set to 0, this property is ignored (no limit is applied).
+		/// </summary>
+		public ulong InstructionLimit { get; set; } = 0;
 	}
 }

--- a/src/WattleScript.Tests/EndToEnd/CLikeTestRunner.cs
+++ b/src/WattleScript.Tests/EndToEnd/CLikeTestRunner.cs
@@ -45,6 +45,7 @@ public class CLikeTestRunner
         StringBuilder stdOut = new StringBuilder();
 
         Script script = new Script(CoreModules.Preset_HardSandboxWattle | CoreModules.PrototypeTable);
+        script.Options.InstructionLimit = ulong.MaxValue;
         script.Options.DebugPrint = s => stdOut.AppendLine(s);
         script.Options.IndexTablesFrom = 0;
         script.Options.AnnotationPolicy = new CustomPolicy(AnnotationValueParsingPolicy.ForceTable);

--- a/src/WattleScript.Tests/EndToEnd/CLikeTestRunner.cs
+++ b/src/WattleScript.Tests/EndToEnd/CLikeTestRunner.cs
@@ -45,7 +45,7 @@ public class CLikeTestRunner
         StringBuilder stdOut = new StringBuilder();
 
         Script script = new Script(CoreModules.Preset_HardSandboxWattle | CoreModules.PrototypeTable);
-        script.Options.InstructionLimit = ulong.MaxValue;
+        script.Options.InstructionLimit = 100_000_000;
         script.Options.DebugPrint = s => stdOut.AppendLine(s);
         script.Options.IndexTablesFrom = 0;
         script.Options.AnnotationPolicy = new CustomPolicy(AnnotationValueParsingPolicy.ForceTable);


### PR DESCRIPTION
Exposed in ScriptOptions.InstructionLimit, defaults to 0 = ignored. Changed several related longs to ulongs.