### PR TITLE
Implement CopyTo and GetEnumerator on FastStack

### DIFF
--- a/src/WattleScript.Interpreter/DataStructs/FastStack.cs
+++ b/src/WattleScript.Interpreter/DataStructs/FastStack.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace WattleScript.Interpreter.DataStructs
 {
@@ -170,7 +171,7 @@ namespace WattleScript.Interpreter.DataStructs
 
 		void ICollection<T>.CopyTo(T[] array, int arrayIndex)
 		{
-			throw new NotImplementedException();
+			m_Storage.Take(m_HeadIdx).ToArray().CopyTo(array, arrayIndex);
 		}
 
 		int ICollection<T>.Count
@@ -190,7 +191,7 @@ namespace WattleScript.Interpreter.DataStructs
 
 		IEnumerator<T> IEnumerable<T>.GetEnumerator()
 		{
-			throw new NotImplementedException();
+			return (IEnumerator<T>) m_Storage.GetEnumerator();
 		}
 
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()


### PR DESCRIPTION
Saves about 3 clicks when I'm debugging contents of FastStack instances. Old route was via Raw View.

![image](https://user-images.githubusercontent.com/10260230/169662393-ebff9c3a-5b29-4d11-9ec9-cac7d81dd5d6.png)
