### PR TITLE
Update modules branding, clean PrototypeModule

### DIFF
--- a/src/WattleScript.Interpreter/CoreLib/BasicModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/BasicModule.cs
@@ -10,7 +10,7 @@ using WattleScript.Interpreter.Debugging;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing basic Lua functions (print, type, tostring, etc) as a WattleScript module.
+	/// Class implementing basic Wattle & Lua functions (print, type, tostring, etc) as a WattleScript module.
 	/// </summary>
 	[WattleScriptModule]
 	public class BasicModule

--- a/src/WattleScript.Interpreter/CoreLib/Bit32Module.cs
+++ b/src/WattleScript.Interpreter/CoreLib/Bit32Module.cs
@@ -6,7 +6,7 @@ using System;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing bit32 Lua functions 
+	/// Class implementing bit32 Wattle & Lua functions 
 	/// </summary>
 	[WattleScriptModule(Namespace = "bit32")]
 	public class Bit32Module

--- a/src/WattleScript.Interpreter/CoreLib/CoroutineModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/CoroutineModule.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing coroutine Lua functions 
+	/// Class implementing coroutine Wattle & Lua functions 
 	/// </summary>
 	[WattleScriptModule(Namespace = "coroutine")]
 	public class CoroutineModule

--- a/src/WattleScript.Interpreter/CoreLib/DebugModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/DebugModule.cs
@@ -9,7 +9,7 @@ using WattleScript.Interpreter.REPL;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing debug Lua functions. Support for the debug module is partial. 
+	/// Class implementing debug Wattle & Lua functions. Support for the debug module is partial. 
 	/// </summary>
 	[WattleScriptModule(Namespace = "debug")]
 	public class DebugModule

--- a/src/WattleScript.Interpreter/CoreLib/DynamicModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/DynamicModule.cs
@@ -5,7 +5,7 @@
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing dynamic expression evaluations at runtime (a WattleScript addition).
+	/// Class implementing dynamic expression evaluations at runtime (not a part of standard Lua lib).
 	/// </summary>
 	[WattleScriptModule(Namespace = "dynamic")]
 	public class DynamicModule

--- a/src/WattleScript.Interpreter/CoreLib/ErrorHandlingModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/ErrorHandlingModule.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing error handling Lua functions (pcall and xpcall)
+	/// Class implementing error handling Wattle & Lua functions (pcall and xpcall)
 	/// </summary>
 	[WattleScriptModule]
 	public class ErrorHandlingModule

--- a/src/WattleScript.Interpreter/CoreLib/IoModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/IoModule.cs
@@ -12,7 +12,7 @@ using WattleScript.Interpreter.Platforms;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing io Lua functions. Proper support requires a compatible IPlatformAccessor
+	/// Class implementing io Wattle & Lua functions. Proper support requires a compatible IPlatformAccessor
 	/// </summary>
 	[WattleScriptModule(Namespace = "io")]
 	public class IoModule

--- a/src/WattleScript.Interpreter/CoreLib/LoadModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/LoadModule.cs
@@ -5,7 +5,7 @@
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing loading Lua functions like 'require', 'load', etc.
+	/// Class implementing loading Wattle & Lua functions like 'require', 'load', etc.
 	/// </summary>
 	[WattleScriptModule]
 	public class LoadModule

--- a/src/WattleScript.Interpreter/CoreLib/MathModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/MathModule.cs
@@ -7,7 +7,7 @@ using WattleScript.Interpreter.Interop;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing math Lua functions 
+	/// Class implementing math Wattle & Lua functions 
 	/// </summary>
 	[WattleScriptModule(Namespace = "math")]
 	public class MathModule

--- a/src/WattleScript.Interpreter/CoreLib/MetaTableModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/MetaTableModule.cs
@@ -5,7 +5,7 @@
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing metatable related Lua functions (xxxmetatable and rawxxx).
+	/// Class implementing metatable related Wattle & Lua functions (xxxmetatable and rawxxx).
 	/// </summary>
 	[WattleScriptModule]
 	public class MetaTableModule

--- a/src/WattleScript.Interpreter/CoreLib/OsSystemModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/OsSystemModule.cs
@@ -6,7 +6,7 @@ using System;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing system related Lua functions from the 'os' module.
+	/// Class implementing system related Wattle & Lua functions from the 'os' module.
 	/// Proper support requires a compatible IPlatformAccessor
 	/// </summary>
 	[WattleScriptModule(Namespace = "os")]

--- a/src/WattleScript.Interpreter/CoreLib/OsTimeModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/OsTimeModule.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing time related Lua functions from the 'os' module.
+	/// Class implementing time related Wattle & Lua functions from the 'os' module.
 	/// </summary>
 	[WattleScriptModule(Namespace = "os")]
 	public class OsTimeModule

--- a/src/WattleScript.Interpreter/CoreLib/PrototypeModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/PrototypeModule.cs
@@ -1,6 +1,9 @@
 
 namespace WattleScript.Interpreter.CoreLib
 {
+    /// <summary>
+    /// Class implementing prototype Wattle & Lua functions 
+    /// </summary>
     [WattleScriptModule(Namespace = "prototype")]
     public class PrototypeModule
     {
@@ -23,40 +26,35 @@ namespace WattleScript.Interpreter.CoreLib
         {
             var sc = globalTable.OwnerScript;
             var stringTable = globalTable.Get("string").Table;
+            
+            void Register(string prototableIdent, DataType protoType)
+            {
+                //register
+                var tab = new Table(sc);
+                var funcs = new Table(sc);
+                tab.Set("__index", DynValue.NewTable(funcs));
+                sc.SetTypeMetatable(protoType, tab);
+                sc.Registry.Set(prototableIdent, DynValue.NewTable(funcs));
+                //functions
+                funcs.Set("tostring", DynValue.NewCallback(BasicModule.tostring, "tostring"));
+            }
+            
             if (sc.Registry.Get(NUMBER_PROTOTABLE).IsNil())
             {
-                //register
-                var nTab = new Table(sc);
-                var nFuncs = new Table(sc);
-                nTab.Set("__index", DynValue.NewTable(nFuncs));
-                sc.SetTypeMetatable(DataType.Number, nTab);
-                sc.Registry.Set(NUMBER_PROTOTABLE, DynValue.NewTable(nFuncs));
-                //functions
-                nFuncs.Set("tostring", DynValue.NewCallback(BasicModule.tostring, "tostring"));
+                Register(NUMBER_PROTOTABLE, DataType.Number);
             }
+            
             if (sc.Registry.Get(BOOLEAN_PROTOTABLE).IsNil())
             {
-                //register
-                var bTab = new Table(sc);
-                var bFuncs = new Table(sc);
-                bTab.Set("__index", DynValue.NewTable(bFuncs));
-                sc.SetTypeMetatable(DataType.Boolean, bTab);
-                sc.Registry.Set(BOOLEAN_PROTOTABLE, DynValue.NewTable(bFuncs));
-                //functions
-                bFuncs.Set("tostring", DynValue.NewCallback(BasicModule.tostring, "tostring"));
+                Register(BOOLEAN_PROTOTABLE, DataType.Boolean);
             }
+            
             if (sc.Registry.Get(RANGE_PROTOTABLE).IsNil())
             {
-                //register
-                var rTab = new Table(sc);
-                var rFuncs = new Table(sc);
-                rTab.Set("__index", DynValue.NewTable(rFuncs));
-                sc.SetTypeMetatable(DataType.Range, rTab);
-                sc.Registry.Set(RANGE_PROTOTABLE, DynValue.NewTable(rFuncs));
-                //functions
-                rFuncs.Set("tostring", DynValue.NewCallback(BasicModule.tostring, "tostring"));
+                Register(RANGE_PROTOTABLE, DataType.Range);
             }
-            if(sc.GetTablePrototype() == null)
+            
+            if (sc.GetTablePrototype() == null)
                 sc.SetTablePrototype(new Table(sc));
             //Copy tostring to string table
             stringTable.Set("tostring", DynValue.NewCallback(BasicModule.tostring, "tostring"));

--- a/src/WattleScript.Interpreter/CoreLib/StringModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/StringModule.cs
@@ -9,7 +9,7 @@ using WattleScript.Interpreter.CoreLib.StringLib;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing string Lua functions 
+	/// Class implementing string Wattle & Lua functions 
 	/// </summary>
 	[WattleScriptModule(Namespace = "string")]
 	public class StringModule

--- a/src/WattleScript.Interpreter/CoreLib/TableIteratorsModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/TableIteratorsModule.cs
@@ -5,7 +5,7 @@
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing table Lua iterators (pairs, ipairs, next)
+	/// Class implementing table Wattle & Lua iterators (pairs, ipairs, next)
 	/// </summary>
 	[WattleScriptModule]
 	public class TableIteratorsModule

--- a/src/WattleScript.Interpreter/CoreLib/TableModule.cs
+++ b/src/WattleScript.Interpreter/CoreLib/TableModule.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace WattleScript.Interpreter.CoreLib
 {
 	/// <summary>
-	/// Class implementing table Lua functions 
+	/// Class implementing table Wattle & Lua functions 
 	/// </summary>
 	[WattleScriptModule(Namespace = "table")]
 	public class TableModule

--- a/src/WattleScript.Interpreter/Modules/ModuleRegister.cs
+++ b/src/WattleScript.Interpreter/Modules/ModuleRegister.cs
@@ -90,6 +90,8 @@ namespace WattleScript.Interpreter
 		/// <exception cref="System.ArgumentException">If the module contains some incompatibility</exception>
 		public static Table RegisterModuleType(this Table gtable, Type t)
 		{
+			const string WATTLE_SCRIPT_INIT = "WattleScriptInit";
+			
 			Table table = CreateModuleNamespace(gtable, t);
 
 			foreach (MethodInfo mi in t.GetAllMethods().Where(__mi => __mi.IsStatic))
@@ -112,7 +114,7 @@ namespace WattleScript.Interpreter
 
 					table.Set(name, DynValue.NewCallback(func, name));
 				}
-				else if (mi.Name == "WattleScriptInit")
+				else if (mi.Name == WATTLE_SCRIPT_INIT)
 				{
 					object[] args = new object[2] { gtable, table };
 					mi.Invoke(null, args);


### PR DESCRIPTION
- in modules `Lua` in the header comments replaced with `Wattle & Lua`
- refactored shared logic from `PrototypeModule` into a method
- `ModuleRegister` -> magic string extracted to a const