### PR TITLE
Backport changes to core from templating engine branch

### DIFF
--- a/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
@@ -43,9 +43,11 @@ namespace WattleScript.Interpreter.Execution.VM
         internal Instruction[] code;
         internal SourceRef[] sourceRefs;
         
-        public string GetSourceCode(string fullSourceCode)
+        public string GetSourceFragment(string fullSourceCode)
         {
-            return sourceRefs.GetSourceCode(fullSourceCode);
+            return sourceRefs.GetSourceFragment(fullSourceCode);
         }
+
+        public IReadOnlyList<SourceRef> SourceRefs => sourceRefs;
     }
 }

--- a/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/FunctionProto.cs
@@ -42,5 +42,10 @@ namespace WattleScript.Interpreter.Execution.VM
         // Source Code
         internal Instruction[] code;
         internal SourceRef[] sourceRefs;
+        
+        public string GetSourceCode(string fullSourceCode)
+        {
+            return sourceRefs.GetSourceCode(fullSourceCode);
+        }
     }
 }

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
@@ -224,7 +224,7 @@ namespace WattleScript.Interpreter.Execution.VM
 			proto.code = new Instruction[br.ReadVarUInt32()];
 			proto.sourceRefs = new SourceRef[proto.code.Length];
 			for (int i = 0; i < proto.code.Length; i++) proto.code[i] = Instruction.ReadBinary(br);
-			SourceRef sourceRef = new SourceRef(sourceID);
+
 			if (br.ReadBoolean())
 			{
 				//Debug info!
@@ -233,7 +233,7 @@ namespace WattleScript.Interpreter.Execution.VM
 					switch (br.ReadByte())
 					{
 						case 0:
-							proto.sourceRefs[i] = sourceRef;
+							proto.sourceRefs[i] = null;
 							break;
 						case 1:
 							proto.sourceRefs[i] = proto.sourceRefs[i - 1];
@@ -247,7 +247,7 @@ namespace WattleScript.Interpreter.Execution.VM
 			else
 			{
 				//No debug info
-				for (int i = 0; i < proto.sourceRefs.Length; i++) proto.sourceRefs[i] = sourceRef;
+				for (int i = 0; i < proto.sourceRefs.Length; i++) proto.sourceRefs[i] = null;
 			}
 			return proto;
 		}

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_BinaryDump.cs
@@ -224,7 +224,7 @@ namespace WattleScript.Interpreter.Execution.VM
 			proto.code = new Instruction[br.ReadVarUInt32()];
 			proto.sourceRefs = new SourceRef[proto.code.Length];
 			for (int i = 0; i < proto.code.Length; i++) proto.code[i] = Instruction.ReadBinary(br);
-			SourceRef sourceRef = new SourceRef(sourceID, 0, 0, 0, 0, false);
+			SourceRef sourceRef = new SourceRef(sourceID);
 			if (br.ReadBoolean())
 			{
 				//Debug info!

--- a/src/WattleScript.Interpreter/Extensions.cs
+++ b/src/WattleScript.Interpreter/Extensions.cs
@@ -6,7 +6,7 @@ namespace WattleScript.Interpreter
 {
     public static class Extensions
     {
-        public static string GetSourceCode(this SourceRef[] refs, string fullSourceCode)
+        public static string GetSourceFragment(this SourceRef[] refs, string fullSourceCode)
         {
             if (refs == null)
             {

--- a/src/WattleScript.Interpreter/Extensions.cs
+++ b/src/WattleScript.Interpreter/Extensions.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using WattleScript.Interpreter.Debugging;
+
+namespace WattleScript.Interpreter
+{
+    public static class Extensions
+    {
+        public static string GetSourceCode(this SourceRef[] refs, string fullSourceCode)
+        {
+            if (refs == null)
+            {
+                return "";
+            }
+			
+            SourceRef firstNotNull = refs.FirstOrDefault(x => x != null);
+            SourceRef lastNotNull = refs.LastOrDefault(x => x != null);
+			
+            if (firstNotNull != null && lastNotNull == null)
+            {
+                return fullSourceCode.Substring(firstNotNull.FromCharIndex, firstNotNull.ToCharIndex - firstNotNull.FromCharIndex);
+            }
+			
+            if (firstNotNull == null && lastNotNull != null)
+            {
+                return fullSourceCode.Substring(lastNotNull.FromCharIndex, lastNotNull.ToCharIndex - lastNotNull.FromCharIndex);
+            }
+
+            return fullSourceCode.Substring(firstNotNull?.FromCharIndex ?? 0, lastNotNull?.ToCharIndex - firstNotNull?.FromCharIndex ?? 0);
+        }
+    }
+}

--- a/src/WattleScript.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
+++ b/src/WattleScript.Interpreter/Tree/Expressions/FunctionDefinitionExpression.cs
@@ -30,7 +30,7 @@ namespace WattleScript.Interpreter.Tree.Expressions
 		bool m_UsesGlobalEnv;
 		SymbolRef m_Env;
 
-		SourceRef m_Begin, m_End;
+		internal SourceRef m_Begin, m_End;
 		private ScriptLoadingContext lcontext;
 		List<FunctionDefinitionStatement.FunctionParamRef> paramnames;
 		private bool m_IsConstructor;
@@ -370,6 +370,12 @@ namespace WattleScript.Interpreter.Tree.Expressions
 			if(parent != null) parent.Protos.Add(proto);
 			
 			return proto;
+		}
+		
+		public void Compile(FunctionBuilder bc, string friendlyName)
+		{
+			CompileBody(bc, bc.Script, friendlyName);			
+			bc.Emit_Closure(bc.Protos.Count - 1);
 		}
 
 		public void Compile(FunctionBuilder bc, Func<int> afterDecl, string friendlyName)

--- a/src/WattleScript.Interpreter/Tree/Lexer/Lexer.cs
+++ b/src/WattleScript.Interpreter/Tree/Lexer/Lexer.cs
@@ -1152,21 +1152,16 @@ namespace WattleScript.Interpreter.Tree
 			return CreateToken(TokenType.Directive, fromLine, fromCol, builder.ToString());
 		}
 
-
 		private Token CreateToken(TokenType tokenType, int fromLine, int fromCol, string text = null)
 		{
 			//Make sure negative values aren't created in tokens
 			//Breaks other things
-			Token t = new Token(tokenType, m_SourceId, 
-				fromLine < 1 ? 1 : fromLine, 
-				fromCol < 0 ? 0 : fromCol, 
-				m_Line < 1 ? 1 : m_Line, 
+			Token t = new Token(tokenType, m_SourceId,
+				fromLine < 1 ? 1 : fromLine,
+				fromCol < 0 ? 0 : fromCol,
+				m_Line < 1 ? 1 : m_Line,
 				m_Col < 0 ? 0 : m_Col,
-				m_PrevLineTo, m_PrevColTo)
-			{
-				Text = text
-				
-			};
+				m_PrevLineTo, m_PrevColTo, m_Cursor - (text?.Length ?? 0), m_Cursor, text);
 			m_PrevLineTo = m_Line < 1 ? 1 : m_Line;
 			m_PrevColTo = m_Col < 0 ? 0 : m_Col;
 			return t;

--- a/src/WattleScript.Interpreter/Tree/Lexer/Token.cs
+++ b/src/WattleScript.Interpreter/Tree/Lexer/Token.cs
@@ -5,14 +5,13 @@ namespace WattleScript.Interpreter.Tree
 	class Token
 	{
 		public readonly int SourceId;
-		public readonly int FromCol, ToCol, FromLine, ToLine, PrevCol, PrevLine;
+		public readonly int FromCol, ToCol, FromLine, ToLine, PrevCol, PrevLine, CharIndexTo, CharIndexFrom;
 		public readonly TokenType Type;
 		public string Text { get; set; }
 
-		public Token(TokenType type, int sourceId, int fromLine, int fromCol, int toLine, int toCol, int prevLine, int prevCol)
+		public Token(TokenType type, int sourceId, int fromLine, int fromCol, int toLine, int toCol, int prevLine, int prevCol, int charIndexFrom, int charIndexTo, string text)
 		{
 			Type = type;
-
 			SourceId = sourceId;
 			FromLine = fromLine;
 			FromCol = fromCol;
@@ -20,17 +19,20 @@ namespace WattleScript.Interpreter.Tree
 			ToLine = toLine;
 			PrevCol = prevCol;
 			PrevLine = prevLine;
+			CharIndexTo = charIndexTo;
+			CharIndexFrom = charIndexFrom;
+			Text = text;
 		}
 
 		public override string ToString()
 		{
-			string tokenTypeString = (Type.ToString() + "                                                      ").Substring(0, 16);
+			string tokenTypeString = (Type + "                                                      ").Substring(0, 16);
 
-			string location = string.Format("{0}:{1}-{2}:{3}", FromLine, FromCol, ToLine, ToCol);
+			string location = $"{FromLine}:{FromCol}-{ToLine}:{ToCol}";
 
 			location = (location + "                                                      ").Substring(0, 10);
 
-			return string.Format("{0}  - {1} - '{2}'", tokenTypeString, location, this.Text ?? "");
+			return $"{tokenTypeString}  - {location} - '{Text ?? ""}'";
 		}
 
 		public static TokenType? GetReservedTokenType(string reservedWord, ScriptSyntax syntax)
@@ -93,14 +95,13 @@ namespace WattleScript.Interpreter.Tree
 
 		public double GetNumberValue()
 		{
-			if (this.Type == TokenType.Number)
-				return LexerUtils.ParseNumber(this);
-			else if (this.Type == TokenType.Number_Hex)
-				return LexerUtils.ParseHexInteger(this);
-			else if (this.Type == TokenType.Number_HexFloat)
-				return LexerUtils.ParseHexFloat(this);
-			else
-				throw new NotSupportedException("GetNumberValue is supported only on numeric tokens");
+			return Type switch
+			{
+				TokenType.Number => LexerUtils.ParseNumber(this),
+				TokenType.Number_Hex => LexerUtils.ParseHexInteger(this),
+				TokenType.Number_HexFloat => LexerUtils.ParseHexFloat(this),
+				_ => throw new NotSupportedException("GetNumberValue is supported only on numeric tokens")
+			};
 		}
 
 
@@ -165,17 +166,17 @@ namespace WattleScript.Interpreter.Tree
 
 		internal Debugging.SourceRef GetSourceRef(bool isStepStop = true)
 		{
-			return new Debugging.SourceRef(this.SourceId, this.FromCol, this.ToCol, this.FromLine, this.ToLine, isStepStop);
+			return new Debugging.SourceRef(SourceId, FromCol, ToCol, FromLine, ToLine, isStepStop, CharIndexFrom, CharIndexTo);
 		}
 
 		internal Debugging.SourceRef GetSourceRef(Token to, bool isStepStop = true)
 		{
-			return new Debugging.SourceRef(this.SourceId, this.FromCol, to.ToCol, this.FromLine, to.ToLine, isStepStop);
+			return new Debugging.SourceRef(SourceId, FromCol, to.ToCol, FromLine, to.ToLine, isStepStop, CharIndexFrom, CharIndexTo);
 		}
 
 		internal Debugging.SourceRef GetSourceRefUpTo(Token to, bool isStepStop = true)
 		{
-			return new Debugging.SourceRef(this.SourceId, this.FromCol, to.PrevCol, this.FromLine, to.PrevLine, isStepStop);
+			return new Debugging.SourceRef(SourceId, FromCol, to.PrevCol, FromLine, to.PrevLine, isStepStop, CharIndexFrom, CharIndexTo);
 		}
 	}
 }

--- a/src/WattleScript.Interpreter/Tree/Preprocessor/DirectiveLexer.cs
+++ b/src/WattleScript.Interpreter/Tree/Preprocessor/DirectiveLexer.cs
@@ -272,11 +272,7 @@ namespace WattleScript.Interpreter.Tree
         
         Token CreateToken(TokenType tokenType, int fromLine, int fromCol, string text = null)
         {
-            var ret = new Token(tokenType, sourceIndex, fromLine, fromCol, fromLine, fromCol + text?.Length ?? 0, 0, 0)
-            {
-                Text = text
-            };
-            return ret;
+            return new Token(tokenType, sourceIndex, fromLine, fromCol, fromLine, fromCol + text?.Length ?? 0, 0, 0, cur.Index - (text?.Length ?? 0), cur.Index, text);
         }
         
         public void CheckEndOfLine()

--- a/src/WattleScript.Interpreter/Tree/Preprocessor/Preprocessor.cs
+++ b/src/WattleScript.Interpreter/Tree/Preprocessor/Preprocessor.cs
@@ -447,11 +447,7 @@ namespace WattleScript.Interpreter.Tree
         
         Token CreateToken(TokenType tokenType, int fromLine, int fromCol, string text = null)
         {
-            var ret = new Token(tokenType, sourceIndex, fromLine, fromCol, fromLine, fromCol + text?.Length ?? 0, 0, 0)
-            {
-                Text = text
-            };
-            return ret;
+            return new Token(tokenType, sourceIndex, fromLine, fromCol, fromLine, fromCol + text?.Length ?? 0, 0, 0, cursor.Index - (text?.Length ?? 0), cursor.Index, text);
         }
 
         public string ProcessedSource => output.ToString();

--- a/src/WattleScript.Interpreter/Tree/Statements/ClassDefinitionStatement.cs
+++ b/src/WattleScript.Interpreter/Tree/Statements/ClassDefinitionStatement.cs
@@ -355,7 +355,7 @@ namespace WattleScript.Interpreter.Tree.Statements
             foreach (var fn in functions)
             {
                 bc.Emit_Literal(DynValue.NewString(fn.name));
-                fn.exp.Compile(bc, () => 0, fn.name);
+                fn.exp.Compile(bc, fn.name);
             }
             bc.Emit_TblInitN(functions.Count * 2, 1);
             //compile __tostring metamethod
@@ -368,7 +368,7 @@ namespace WattleScript.Interpreter.Tree.Statements
             //make ctor function 
             bc.Emit_Literal(DynValue.NewString("__ctor"));
             if (constructor != null) {
-                constructor.Compile(bc, () => 0, className + ".ctor");   
+                constructor.Compile(bc, className + ".ctor");   
                 constructorLocal.CompileAssignment(bc, Operator.NotAnOperator, 0, 0);
             }
             else {

--- a/src/WattleScript.Interpreter/Tree/Statements/FunctionDefinitionStatement.cs
+++ b/src/WattleScript.Interpreter/Tree/Statements/FunctionDefinitionStatement.cs
@@ -57,18 +57,21 @@ namespace WattleScript.Interpreter.Tree.Statements
 			m_Local = local;
 			Token name = CheckTokenType(lcontext, TokenType.Name);
 			SelfType selfType = SelfType.None;
+			SourceRef funcKeywordSourceRef;
 			
 			if (m_Local)
 			{
 				m_FuncDefName = name.Text;
 				m_FriendlyName = string.Format("{0} (local)", name.Text);
 				m_SourceRef = funcKeyword.GetSourceRef(name);
+				funcKeywordSourceRef = funcKeyword.GetSourceRef();
 			}
 			else
 			{
 				string firstName = name.Text;
 
 				m_SourceRef = funcKeyword.GetSourceRef(name);
+				funcKeywordSourceRef = funcKeyword.GetSourceRef();
 				m_FuncLookupSymbol = firstName;
 
 				m_FriendlyName = firstName;
@@ -118,6 +121,7 @@ namespace WattleScript.Interpreter.Tree.Statements
 			}
 			
 			m_FuncDef = new FunctionDefinitionExpression(lcontext, selfType, false);
+			m_FuncDef.m_Begin = funcKeywordSourceRef;
 			lcontext.Source.Refs.Add(m_SourceRef);
 		}
 

--- a/src/WattleScript.Tests/EndToEnd/CLikeTestRunner.cs
+++ b/src/WattleScript.Tests/EndToEnd/CLikeTestRunner.cs
@@ -4,12 +4,16 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using WattleScript.Interpreter.Debugging;
 
 namespace WattleScript.Interpreter.Tests;
 
 public class CLikeTestRunner
 {
     private const string ROOT_FOLDER = "EndToEnd/CLike";
+    private const bool TEST_SOURCE_REFS_DUMP = true;
+    
+    StringBuilder stdOut = new StringBuilder();
 
     static string[] GetTestCases()
     {
@@ -30,6 +34,22 @@ public class CLikeTestRunner
         await RunCore(path, true);
     }
     
+    Script InitScript()
+    {
+        Script script = new Script(CoreModules.Preset_SoftSandboxWattle);
+        script.Options.IndexTablesFrom = 0;
+        script.Options.Syntax = ScriptSyntax.Wattle;
+        script.Options.AnnotationPolicy.AnnotationParsingPolicy = AnnotationValueParsingPolicy.ForceTable;
+        script.Options.InstructionLimit = 100_000_000;
+        script.Options.DebugPrint = s => stdOut.AppendLine(s);
+        script.Options.IndexTablesFrom = 0;
+        script.Options.AnnotationPolicy = new CustomPolicy(AnnotationValueParsingPolicy.ForceTable);
+        script.Globals["CurrentLine"] = (ScriptExecutionContext c, CallbackArguments a) => c.CallingLocation.FromLine;
+        script.Globals["CurrentColumn"] = (ScriptExecutionContext c, CallbackArguments a) => c.CallingLocation.FromChar;
+
+        return script;
+    }
+    
     public async Task RunCore(string path, bool reportErrors = false)
     {
         string outputPath = path.Replace(".lua", ".txt");
@@ -42,19 +62,9 @@ public class CLikeTestRunner
 
         string code = await File.ReadAllTextAsync(path);
         string output = await File.ReadAllTextAsync(outputPath);
-        StringBuilder stdOut = new StringBuilder();
+        stdOut = new StringBuilder();
 
-        Script script = new Script(CoreModules.Preset_SoftSandboxWattle);
-        script.Options.InstructionLimit = 100_000_000;
-        script.Options.DebugPrint = s => stdOut.AppendLine(s);
-        script.Options.IndexTablesFrom = 0;
-        script.Options.AnnotationPolicy = new CustomPolicy(AnnotationValueParsingPolicy.ForceTable);
-        script.Globals["CurrentLine"] = (ScriptExecutionContext c, CallbackArguments a) => {
-            return c.CallingLocation.FromLine;
-        };
-        script.Globals["CurrentColumn"] = (ScriptExecutionContext c, CallbackArguments a) => {
-            return c.CallingLocation.FromChar;
-        };
+        Script script = InitScript();
         if (path.Contains("flaky"))
         {
             Assert.Inconclusive($"Test {path} marked as flaky");
@@ -78,11 +88,18 @@ public class CLikeTestRunner
             DynValue dv = script.LoadString(code);
             IReadOnlyList<Annotation> annots = dv.Function.Annotations;
             await script.CallAsync(dv);
-
-            DynValue dv2 = script.Globals.Get("f");
             
             Assert.AreEqual(output.Trim(), stdOut.ToString().Trim(), $"Test {path} did not pass.");
 
+            if (TEST_SOURCE_REFS_DUMP)
+            {
+                Exception e = TestSourceRefsBinDump(code);
+                if (e != null)
+                {
+                    Assert.Fail($"Dumped source refs not equal to original.\n{e.Message}\n{e.StackTrace}");
+                }
+            }
+            
             if (path.Contains("invalid"))
             {
                 Assert.Fail("Expected to crash but 'passed'");
@@ -109,5 +126,42 @@ public class CLikeTestRunner
             }
             Assert.Fail($"Test {path} did not pass.\nMessage: {e.Message}\n{e.StackTrace}");
         }
+    }
+    
+    public Exception TestSourceRefsBinDump(string code)
+    {
+        Script sc = InitScript();
+        DynValue dv = sc.LoadString(code);
+        IReadOnlyList<SourceRef> originalSourceRefs = dv.Function.Function.SourceRefs;
+
+        using MemoryStream ms = new MemoryStream();
+        sc.Dump(dv, ms);
+        ms.Seek(0, SeekOrigin.Begin);
+        sc = InitScript();
+        dv = sc.LoadStream(ms);
+        dv.Function.Call();
+
+        IReadOnlyList<SourceRef> dumpedSourceRefs = dv.Function.Function.SourceRefs;
+        Assert.AreEqual(originalSourceRefs.Count, dumpedSourceRefs.Count, "Dumped different number of source refs");
+
+        for (int i = 0; i < originalSourceRefs.Count; i++)
+        {
+            SourceRef original = originalSourceRefs[i];
+            SourceRef dumped = dumpedSourceRefs[i];
+
+            if (original == null && dumped == null)
+            {
+                continue;
+            }
+
+            if (original == null != (dumped == null))
+            {
+                Assert.Fail($"Dumped source ref {i} isNull differs from original");
+            }
+
+            Assert.That(original.Equals(dumped), $"Dumped source ref {i} differs from original");
+        }
+
+        return null;
     }
 }

--- a/src/WattleScript.Tests/EndToEnd/CSyntaxTests.cs
+++ b/src/WattleScript.Tests/EndToEnd/CSyntaxTests.cs
@@ -156,6 +156,8 @@ namespace WattleScript.Interpreter.Tests.EndToEnd
         {
             var s = new Script();
             s.Options.Syntax = ScriptSyntax.Wattle;
+            s.Options.AnnotationPolicy.AnnotationParsingPolicy = AnnotationValueParsingPolicy.StringOrTable;
+            
             var chunk = s.LoadString(@"
             @@number (1.0)
             @@string ('hello')


### PR DESCRIPTION
This is a collection of tweaks that I'm using ahead of master in TE branch, this PR aims to backport them to master.

- added `FromCharIndex`, `ToCharIndex` to `SourceRef`
- added missing xmldoc in `Script`, fixed xmldoc params mismatch, added a few utility methods, general cleanup
- `SourceRef[]` can now dump source code given a `Script`. Used in `FunctionProto` to dump the code when splitting multiple tag helpers into self-contained units
- removed empty calls in `ClassDefinitionStatement->Compile`
- in `SourceRef` removed `private set` from a few fields, the goal is to compute hash via readonly properties. Still TBD but a good first move.