### PR TITLE
Cleanup slice

### DIFF
--- a/src/WattleScript.Interpreter/DataStructs/Slice.cs
+++ b/src/WattleScript.Interpreter/DataStructs/Slice.cs
@@ -9,11 +9,10 @@ namespace WattleScript.Interpreter.DataStructs
 	/// Provides facility to create a "sliced" view over an existing IList<typeparamref name="T"/>
 	/// </summary>
 	/// <typeparam name="T">The type of the items contained in the collection</typeparam>
-	internal class Slice<T> : IEnumerable<T>, IList<T>
+	internal class Slice<T> : IList<T>
 	{
 		IList<T> m_SourceList;
 		int m_From, m_Length;
-		bool m_Reversed;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Slice{T}"/> class.
@@ -21,13 +20,11 @@ namespace WattleScript.Interpreter.DataStructs
 		/// <param name="list">The list to apply the Slice view on</param>
 		/// <param name="from">From which index</param>
 		/// <param name="length">The length of the slice</param>
-		/// <param name="reversed">if set to <c>true</c> the view is in reversed order.</param>
-		public Slice(IList<T> list, int from, int length, bool reversed)
+		public Slice(IList<T> list, int from, int length)
 		{
 			m_SourceList = list;
 			m_From = from;
 			m_Length = length;
-			m_Reversed = reversed;
 		}
 
 		/// <summary>
@@ -37,60 +34,36 @@ namespace WattleScript.Interpreter.DataStructs
 		/// <returns></returns>
 		public T this[int index]
 		{
-			get 
-			{
-				return m_SourceList[CalcRealIndex(index)];
-			}
-			set
-			{
-				m_SourceList[CalcRealIndex(index)] = value;
-			}
+			get => m_SourceList[CalcRealIndex(index)];
+			set => m_SourceList[CalcRealIndex(index)] = value;
 		}
 
 		/// <summary>
 		/// Gets the index from which the slice starts
 		/// </summary>
-		public int From
-		{
-			get { return m_From; }
-		}
+		public int From => m_From;
 
 		/// <summary>
 		/// Gets the number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.
 		/// </summary>
 		/// <returns>The number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.</returns>
-		public int Count
-		{
-			get { return m_Length; }
-		}
-
+		public int Count => m_Length;
+		
 		/// <summary>
-		/// Gets a value indicating whether this <see cref="Slice{T}"/> operates in a reversed direction.
+		/// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.
 		/// </summary>
-		/// <value>
-		///   <c>true</c> if this <see cref="Slice{T}"/> operates in a reversed direction; otherwise, <c>false</c>.
-		/// </value>
-		public bool Reversed
-		{
-			get { return m_Reversed; }
-		}
-
+		/// <returns>true if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, false.</returns>
+		public bool IsReadOnly => true;
+		
 		/// <summary>
 		/// Calculates the real index in the underlying collection
 		/// </summary>
 		private int CalcRealIndex(int index)
 		{
 			if (index < 0 || index >= m_Length)
-				throw new ArgumentOutOfRangeException("index");
-
-			if (m_Reversed)
-			{
-				return m_From + m_Length - index - 1;
-			}
-			else
-			{
-				return m_From + index;
-			}
+				throw new ArgumentOutOfRangeException(nameof(index));
+			
+			return m_From + index;
 		}
 
 		/// <summary>
@@ -222,15 +195,6 @@ namespace WattleScript.Interpreter.DataStructs
 		{
 			for (int i = 0; i < Count; i++)
 				array[i + arrayIndex] = this[i];
-		}
-
-		/// <summary>
-		/// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.
-		/// </summary>
-		/// <returns>true if the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only; otherwise, false.</returns>
-		public bool IsReadOnly
-		{
-			get { return true; }
 		}
 
 		/// <summary>

--- a/src/WattleScript.Interpreter/DataTypes/CallbackArguments.cs
+++ b/src/WattleScript.Interpreter/DataTypes/CallbackArguments.cs
@@ -221,12 +221,13 @@ namespace WattleScript.Interpreter
 		/// <returns></returns>
 		public CallbackArguments SkipMethodCall()
 		{
-			if (this.IsMethodCall)
+			if (IsMethodCall)
 			{
-				Slice<DynValue> slice = new Slice<DynValue>(m_Args, 1, m_Args.Count - 1, false);
+				Slice<DynValue> slice = new Slice<DynValue>(m_Args, 1, m_Args.Count - 1);
 				return new CallbackArguments(slice, m_implicitThis, false);
 			}
-			else return this;
+			
+			return this;
 		}
 	}
 }

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_InstructionLoop.cs
@@ -597,9 +597,7 @@ namespace WattleScript.Interpreter.Execution.VM
 
 		private void ExecMkTuple(Instruction i)
 		{
-			Slice<DynValue> slice = new Slice<DynValue>(m_ValueStack, m_ValueStack.Count - i.NumVal, i.NumVal, false);
-
-			var v = Internal_AdjustTuple(slice);
+			var v = Internal_AdjustTuple(new Slice<DynValue>(m_ValueStack, m_ValueStack.Count - i.NumVal, i.NumVal));
 			m_ValueStack.RemoveLast(i.NumVal);
 			m_ValueStack.Push(DynValue.NewTuple(v));
 		}
@@ -790,7 +788,7 @@ namespace WattleScript.Interpreter.Execution.VM
 				return values;
 			}
 
-			return new Slice<DynValue>(m_ValueStack, m_ValueStack.Count - numargs - offsFromTop, numargs, false);
+			return new Slice<DynValue>(m_ValueStack, m_ValueStack.Count - numargs - offsFromTop, numargs);
 		}
 		
 		private void ExecArgs(Instruction I)

--- a/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_UtilityFunctions.cs
+++ b/src/WattleScript.Interpreter/Execution/VM/Processor/Processor_UtilityFunctions.cs
@@ -1,49 +1,54 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using WattleScript.Interpreter.DataStructs;
 
 namespace WattleScript.Interpreter.Execution.VM
 {
 	sealed partial class Processor
 	{
-		private DynValue[] Internal_AdjustTuple(IList<DynValue> values)
+		private static DynValue[] Internal_AdjustTuple(IList<DynValue> values)
 		{
-			if (values == null || values.Count == 0)
-				return new DynValue[0];
-
-			if (values[values.Count - 1].Type == DataType.Tuple)
+			while (true)
 			{
-				int baseLen = values.Count - 1 + values[values.Count - 1].Tuple.Length;
-				DynValue[] result = new DynValue[baseLen];
+				if (values == null || values.Count == 0) 
+					return Array.Empty<DynValue>();
 
-				for (int i = 0; i < values.Count - 1; i++)
+				if (values[values.Count - 1].Type == DataType.Tuple)
 				{
-					result[i] = values[i].ToScalar();
-				}
+					int baseLen = values.Count - 1 + values[values.Count - 1].Tuple.Length;
+					DynValue[] result = new DynValue[baseLen];
 
-				for (int i = 0; i < values[values.Count - 1].Tuple.Length; i++)
-				{
-					result[values.Count + i - 1] = values[values.Count - 1].Tuple[i];
-				}
+					for (int i = 0; i < values.Count - 1; i++)
+					{
+						result[i] = values[i].ToScalar();
+					}
 
-				if (result[result.Length - 1].Type == DataType.Tuple)
-					return Internal_AdjustTuple(result);
+					for (int i = 0; i < values[values.Count - 1].Tuple.Length; i++)
+					{
+						result[values.Count + i - 1] = values[values.Count - 1].Tuple[i];
+					}
+
+					if (result[result.Length - 1].Type == DataType.Tuple)
+					{
+						values = result;
+					}
+					else
+						return result;
+				}
 				else
-					return result;
-			}
-			else
-			{
-				DynValue[] result = new DynValue[values.Count];
-
-				for (int i = 0; i < values.Count; i++)
 				{
-					result[i] = values[i].ToScalar();
-				}
+					DynValue[] result = new DynValue[values.Count];
 
-				return result;
+					for (int i = 0; i < values.Count; i++)
+					{
+						result[i] = values[i].ToScalar();
+					}
+
+					return result;
+				}
 			}
 		}
-
-
-
+		
 		private int Internal_InvokeUnaryMetaMethod(DynValue op1, string eventName, int instructionPtr)
 		{
 			DynValue m = DynValue.Nil;
@@ -71,11 +76,10 @@ namespace WattleScript.Interpreter.Execution.VM
 				m_ValueStack.Push(op1);
 				return Internal_ExecCall(false, 1, instructionPtr);
 			}
-			else
-			{
-				return -1;
-			}
+
+			return -1;
 		}
+		
 		private int Internal_InvokeBinaryMetaMethod(DynValue l, DynValue r, string eventName, int instructionPtr, DynValue extraPush = default)
 		{
 			var m = GetBinaryMetamethod(l, r, eventName);
@@ -90,60 +94,8 @@ namespace WattleScript.Interpreter.Execution.VM
 				m_ValueStack.Push(r);
 				return Internal_ExecCall(false, 2, instructionPtr);
 			}
-			else
-			{
-				return -1;
-			}
+
+			return -1;
 		}
-
-
-
-
-		private DynValue[] StackTopToArray(int items, bool pop)
-		{
-			DynValue[] values = new DynValue[items];
-
-			if (pop)
-			{
-				for (int i = 0; i < items; i++)
-				{
-					values[i] = m_ValueStack.Pop();
-				}
-			}
-			else
-			{
-				for (int i = 0; i < items; i++)
-				{
-					values[i] = m_ValueStack[m_ValueStack.Count - 1 - i];
-				}
-			}
-
-			return values;
-		}
-
-		private DynValue[] StackTopToArrayReverse(int items, bool pop)
-		{
-			DynValue[] values = new DynValue[items];
-
-			if (pop)
-			{
-				for (int i = 0; i < items; i++)
-				{
-					values[items - 1 - i] = m_ValueStack.Pop();
-				}
-			}
-			else
-			{
-				for (int i = 0; i < items; i++)
-				{
-					values[items - 1 - i] = m_ValueStack[m_ValueStack.Count - 1 - i];
-				}
-			}
-
-			return values;
-		}
-
-
-
 	}
 }


### PR DESCRIPTION
Removes unused field `reversed` from `Slice`, removes unused functions from `Processor_UtilityFunctions`. Follow up would be to ditch slice in `ExecMkTuple` altogether and do this in zero-allocation way.